### PR TITLE
fix: 카카오 소셜 로그인 access token

### DIFF
--- a/app/src/main/java/com/UMCfront/religo/src/menu/LoginActivity.kt
+++ b/app/src/main/java/com/UMCfront/religo/src/menu/LoginActivity.kt
@@ -56,7 +56,7 @@ class LoginActivity : AppCompatActivity() {
                     // val refreshToken = KaKaoAccessToken(token.refreshToken.toString())
                     // 토큰값 확인
                     Log.d("accessToken 값: ", token.accessToken.toString())
-                    
+
                     LoginService.login(accessToken).enqueue(object : retrofit2.Callback<KakaoResponse> {
                         override fun onResponse(
                             call: retrofit2.Call<KakaoResponse>,
@@ -72,10 +72,10 @@ class LoginActivity : AppCompatActivity() {
                             Log.d("response", "fail")
                         }
                     })
-                    
+
                     val intent= Intent(this, LoadingActivity::class.java)
                     startActivity(intent)
-                    
+
                 }
             }
         }


### PR DESCRIPTION
**구현**

- 카카오 소셜 로그인 코드 수정 + access token 값 서버로 보내기
(header에 Authorization로 보내는 코드 구현)